### PR TITLE
Protobuf の Wrapper を等価な Swagger のプリミティブタイプで代用する

### DIFF
--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -50,7 +50,7 @@ var wktSchemas = map[string]schemaCore{
 	},
 	".google.protobuf.BytesValue": schemaCore{
 		Type:   "string",
-		Format: "bytes",
+		Format: "byte",
 	},
 }
 

--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -48,6 +48,10 @@ var wktSchemas = map[string]schemaCore{
 		Type:   "boolean",
 		Format: "boolean",
 	},
+	".google.protobuf.BytesValue": schemaCore{
+		Type:   "string",
+		Format: "bytes",
+	},
 }
 
 func listEnumNames(enum *descriptor.Enum) (names []string) {
@@ -177,18 +181,20 @@ func findNestedMessagesAndEnumerations(message *descriptor.Message, reg *descrip
 		fieldType := t.GetTypeName()
 		// If the type is an empty string then it is a proto primitive
 		if fieldType != "" {
-			if _, ok := m[fieldType]; !ok {
-				msg, err := reg.LookupMsg("", fieldType)
-				if err != nil {
-					enum, err := reg.LookupEnum("", fieldType)
+			if _, ok := wktSchemas[fieldType]; !ok {
+				if _, ok := m[fieldType]; !ok {
+					msg, err := reg.LookupMsg("", fieldType)
 					if err != nil {
-						panic(err)
+						enum, err := reg.LookupEnum("", fieldType)
+						if err != nil {
+							panic(err)
+						}
+						e[fieldType] = enum
+						continue
 					}
-					e[fieldType] = enum
-					continue
+					m[fieldType] = msg
+					findNestedMessagesAndEnumerations(msg, reg, m, e)
 				}
-				m[fieldType] = msg
-				findNestedMessagesAndEnumerations(msg, reg, m, e)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/elliots/protoc-gen-twirp_swagger/genswagger"
+	"./genswagger"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"


### PR DESCRIPTION
・google.protobuf.StringValue などは swagger の string などに置換されるのに BytesValue だけその処理が組み込まれてなかったので追加。
・また不要な Wrapper モデルが出力されていたので出力されないように修正