### PR TITLE
importの修正 / example/generate-swagger.sh修正

### DIFF
--- a/example/generate-swagger.sh
+++ b/example/generate-swagger.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-go get github.com/elliots/protoc-gen-twirp_swagger
+DIR=$(pwd)
+cd ..
+go build
+cd ${DIR}
 
 protoc --go_out=. \
+       --plugin=../protoc-gen-twirp_swagger \
        --twirp_out=. \
        --twirp_swagger_out=. \
        ./service.proto

--- a/example/service.proto
+++ b/example/service.proto
@@ -5,7 +5,7 @@ option go_package = "example";
 
 // A Hat is a piece of headwear made by a Haberdasher.
 message Hat {
-  //[required] The size of a hat should always be in inches.
+  // [required] The size of a hat should always be in inches.
   int32 size = 1;
 
   // The color of a hat will never be 'invisible', but other than

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"./genswagger"
+	"github.com/filmapp/protoc-gen-twirp_swagger/genswagger"
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"


### PR DESCRIPTION
## 概要
- importを相対パスから変更
- example/generate-swagger.sh 修正
  - ビルドしたバイナリを使ってswagger生成
- コメントの最初に半角スペースを空けるように
  - `// [required]`
  - template.goの修正は必要ありませんでした