### PR TITLE
// [required]だけでもswaggerに吐き出されるように修正

### DIFF
--- a/example/service.proto
+++ b/example/service.proto
@@ -8,6 +8,7 @@ message Hat {
   // [required] The size of a hat should always be in inches.
   int32 size = 1;
 
+  // [required]
   // The color of a hat will never be 'invisible', but other than
   // that, anything is fair game.
   string color = 2;

--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -243,11 +243,7 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 		for _, f := range msg.Fields {
 			fieldValue := schemaOfField(f, reg)
 			rawComments := fieldProtoComments(reg, msg, f)
-			r := strings.NewReplacer(
-				"[required]", "",
-				"\n", "",
-			)
-			comments := r.Replace(rawComments)
+			comments := strings.TrimSpace(strings.TrimPrefix(rawComments, "[required]"))
 			if err := updateSwaggerDataFromComments(&fieldValue, comments); err != nil {
 				panic(err)
 			}

--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -243,7 +243,11 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 		for _, f := range msg.Fields {
 			fieldValue := schemaOfField(f, reg)
 			rawComments := fieldProtoComments(reg, msg, f)
-			comments := strings.TrimPrefix(rawComments, "[required]")
+			r := strings.NewReplacer(
+				"[required]", "",
+				"\n", "",
+			)
+			comments := r.Replace(rawComments)
 			if err := updateSwaggerDataFromComments(&fieldValue, comments); err != nil {
 				panic(err)
 			}

--- a/genswagger/template.go
+++ b/genswagger/template.go
@@ -243,14 +243,14 @@ func renderMessagesAsDefinition(messages messageMap, d swaggerDefinitionsObject,
 		for _, f := range msg.Fields {
 			fieldValue := schemaOfField(f, reg)
 			rawComments := fieldProtoComments(reg, msg, f)
-			comments := strings.TrimPrefix(rawComments, "[required] ")
+			comments := strings.TrimPrefix(rawComments, "[required]")
 			if err := updateSwaggerDataFromComments(&fieldValue, comments); err != nil {
 				panic(err)
 			}
 
 			schema.Properties = append(schema.Properties, keyVal{f.GetName(), fieldValue})
 
-			if strings.HasPrefix(rawComments, "[required] ") {
+			if strings.HasPrefix(rawComments, "[required]") {
 				schema.Required = append(schema.Required, f.GetName())
 			}
 		}


### PR DESCRIPTION
## 概要
- コメントに `[required]` だけが付いていても、swaggerに吐き出されるように修正しました

swagger_.json一部抜粋
```
  "definitions": {
    "exampleHat": {
      "type": "object",
      "properties": {
        "size": {
          "type": "integer",
          "format": "int32",
          "description": "The size of a hat should always be in inches."
        },
        "color": {
          "type": "string",
          "description": "The color of a hat will never be 'invisible', but other than\nthat, anything is fair game."
        },
        "name": {
          "type": "string",
          "description": "The name of a hat is it's type. Like, 'bowler', or something."
        }
      },
      "required": [
        "size",
        "color"
      ],
      "description": "A Hat is a piece of headwear made by a Haberdasher."
    },
```
--------

`sh generate-documentation.sh ` で生成したもの

<img width="837" alt="2018-08-03 14 04 07" src="https://user-images.githubusercontent.com/7755253/43625154-574f9bd4-9726-11e8-9844-f16026277151.png">
